### PR TITLE
so that it can be generated even if there is a dot in the URL.

### DIFF
--- a/dbflute_maihamadb/freegen/remoteapi/RemoteApiRule.js
+++ b/dbflute_maihamadb/freegen/remoteapi/RemoteApiRule.js
@@ -137,6 +137,9 @@ var baseRule = {
      * @return {string} the java sub package of the remote api. (NotNull, NotEmpty)
      */
     subPackage: function(api) {
+        // 1. Remove symbols that cannot be used in java package name. And remove leading and trailing slashes.
+        // 2. Remove path variable.
+        // 3. Replace slashes with dots.
         return api.url.replace(/(_|-|\.|^\/|\/$)/g, '').replace(/\/\{.*?\}/g, '').replace(/\//g, '.').toLowerCase();
     },
 

--- a/dbflute_maihamadb/freegen/remoteapi/RemoteApiRule.js
+++ b/dbflute_maihamadb/freegen/remoteapi/RemoteApiRule.js
@@ -137,7 +137,7 @@ var baseRule = {
      * @return {string} the java sub package of the remote api. (NotNull, NotEmpty)
      */
     subPackage: function(api) {
-        return api.url.replace(/(_|-|^\/|\/$)/g, '').replace(/\/\{.*?\}/g, '').replace(/\..+$/g, '').replace(/\//g, '.').toLowerCase();
+        return api.url.replace(/(_|-|\.|^\/|\/$)/g, '').replace(/\/\{.*?\}/g, '').replace(/\//g, '.').toLowerCase();
     },
 
     // ===================================================================================

--- a/dbflute_maihamadb/output/doc/lastadoc-remoteapigen.html
+++ b/dbflute_maihamadb/output/doc/lastadoc-remoteapigen.html
@@ -21591,6 +21591,24 @@ table.child, table.child td, table.child th {
         <td class="rowcellnum">2</td>
         <td class="rowcell"><a href="#.urlcharacter.dot.dot.::get">/urlcharacter/dot.dot/</a></td>
         <td class="rowcell">get</td>
+        <td class="rowcell">RemoteTrickyUrlcharacterBhv#requestDotdot()</td>
+    </tr>
+    <tr>
+        <td class="rowcellnum">3</td>
+        <td class="rowcell"><a href="#.urlcharacter.dot.dot.dot.::get">/urlcharacter/dot.dot.dot/</a></td>
+        <td class="rowcell">get</td>
+        <td class="rowcell">RemoteTrickyUrlcharacterBhv#requestDotdotdot()</td>
+    </tr>
+    <tr>
+        <td class="rowcellnum">4</td>
+        <td class="rowcell"><a href="#.urlcharacter.file.pdf::get">/urlcharacter/file.pdf</a></td>
+        <td class="rowcell">get</td>
+        <td class="rowcell">RemoteTrickyUrlcharacterBhv#requestFilepdf()</td>
+    </tr>
+    <tr>
+        <td class="rowcellnum">5</td>
+        <td class="rowcell"><a href="#.url.character.dot::get">/url.character/dot</a></td>
+        <td class="rowcell">get</td>
         <td class="rowcell">RemoteTrickyUrlcharacterBhv#requestDot()</td>
     </tr>
     <tr>
@@ -21921,6 +21939,24 @@ table.child, table.child td, table.child th {
 </p>
 <h3 id=".urlcharacter.dot.dot.::get">
 /urlcharacter/dot.dot/ (get)
+</h3>
+<p>
+<span class="doctitle">Request Method:</span> <span class="docmainvalue">RemoteTrickyUrlcharacterBhv#requestDotdot()</span>
+</p>
+<h3 id=".urlcharacter.dot.dot.dot.::get">
+/urlcharacter/dot.dot.dot/ (get)
+</h3>
+<p>
+<span class="doctitle">Request Method:</span> <span class="docmainvalue">RemoteTrickyUrlcharacterBhv#requestDotdotdot()</span>
+</p>
+<h3 id=".urlcharacter.file.pdf::get">
+/urlcharacter/file.pdf (get)
+</h3>
+<p>
+<span class="doctitle">Request Method:</span> <span class="docmainvalue">RemoteTrickyUrlcharacterBhv#requestFilepdf()</span>
+</p>
+<h3 id=".url.character.dot::get">
+/url.character/dot (get)
 </h3>
 <p>
 <span class="doctitle">Request Method:</span> <span class="docmainvalue">RemoteTrickyUrlcharacterBhv#requestDot()</span>

--- a/src/main/java/org/docksidestage/remote/tricky/urlcharacter/BsRemoteTrickyUrlcharacterBhv.java
+++ b/src/main/java/org/docksidestage/remote/tricky/urlcharacter/BsRemoteTrickyUrlcharacterBhv.java
@@ -80,8 +80,8 @@ public abstract class BsRemoteTrickyUrlcharacterBhv extends AbstractRemoteTricky
      * httpMethod: GET
      * </pre>
      */
-    public void requestDot() {
-        doRequestDot(rule -> {});
+    public void requestDotdot() {
+        doRequestDotdot(rule -> {});
     }
 
     /**
@@ -92,15 +92,114 @@ public abstract class BsRemoteTrickyUrlcharacterBhv extends AbstractRemoteTricky
      * </pre>
      * @param ruleLambda The callback for setting rule as dynamic requirement. (NotNull)
      */
-    protected void doRequestDot(Consumer<FlutyRemoteApiRule> ruleLambda) {
+    protected void doRequestDotdot(Consumer<FlutyRemoteApiRule> ruleLambda) {
         doRequestGet(void.class, "/urlcharacter/dot.dot/", noMoreUrl(), noQuery(), rule -> {
-            ruleOfDot(rule);
+            ruleOfDotdot(rule);
             ruleLambda.accept(rule);
         });
     }
 
     /**
      * Set up method-level rule of /urlcharacter/dot.dot/.<br>
+     * @param rule The rule that class default rule is already set. (NotNull)
+     */
+    protected void ruleOfDotdot(FlutyRemoteApiRule rule) {
+    }
+
+    /**
+     * Request remote call to /urlcharacter/dot.dot.dot/. (auto-generated method)<br>
+     * <pre>
+     * url: /urlcharacter/dot.dot.dot/
+     * httpMethod: GET
+     * </pre>
+     */
+    public void requestDotdotdot() {
+        doRequestDotdotdot(rule -> {});
+    }
+
+    /**
+     * Request remote call to /urlcharacter/dot.dot.dot/. (auto-generated method)<br>
+     * <pre>
+     * url: /urlcharacter/dot.dot.dot/
+     * httpMethod: GET
+     * </pre>
+     * @param ruleLambda The callback for setting rule as dynamic requirement. (NotNull)
+     */
+    protected void doRequestDotdotdot(Consumer<FlutyRemoteApiRule> ruleLambda) {
+        doRequestGet(void.class, "/urlcharacter/dot.dot.dot/", noMoreUrl(), noQuery(), rule -> {
+            ruleOfDotdotdot(rule);
+            ruleLambda.accept(rule);
+        });
+    }
+
+    /**
+     * Set up method-level rule of /urlcharacter/dot.dot.dot/.<br>
+     * @param rule The rule that class default rule is already set. (NotNull)
+     */
+    protected void ruleOfDotdotdot(FlutyRemoteApiRule rule) {
+    }
+
+    /**
+     * Request remote call to /urlcharacter/file.pdf. (auto-generated method)<br>
+     * <pre>
+     * url: /urlcharacter/file.pdf
+     * httpMethod: GET
+     * </pre>
+     */
+    public void requestFilepdf() {
+        doRequestFilepdf(rule -> {});
+    }
+
+    /**
+     * Request remote call to /urlcharacter/file.pdf. (auto-generated method)<br>
+     * <pre>
+     * url: /urlcharacter/file.pdf
+     * httpMethod: GET
+     * </pre>
+     * @param ruleLambda The callback for setting rule as dynamic requirement. (NotNull)
+     */
+    protected void doRequestFilepdf(Consumer<FlutyRemoteApiRule> ruleLambda) {
+        doRequestGet(void.class, "/urlcharacter/file.pdf", noMoreUrl(), noQuery(), rule -> {
+            ruleOfFilepdf(rule);
+            ruleLambda.accept(rule);
+        });
+    }
+
+    /**
+     * Set up method-level rule of /urlcharacter/file.pdf.<br>
+     * @param rule The rule that class default rule is already set. (NotNull)
+     */
+    protected void ruleOfFilepdf(FlutyRemoteApiRule rule) {
+    }
+
+    /**
+     * Request remote call to /url.character/dot. (auto-generated method)<br>
+     * <pre>
+     * url: /url.character/dot
+     * httpMethod: GET
+     * </pre>
+     */
+    public void requestDot() {
+        doRequestDot(rule -> {});
+    }
+
+    /**
+     * Request remote call to /url.character/dot. (auto-generated method)<br>
+     * <pre>
+     * url: /url.character/dot
+     * httpMethod: GET
+     * </pre>
+     * @param ruleLambda The callback for setting rule as dynamic requirement. (NotNull)
+     */
+    protected void doRequestDot(Consumer<FlutyRemoteApiRule> ruleLambda) {
+        doRequestGet(void.class, "/url.character/dot", noMoreUrl(), noQuery(), rule -> {
+            ruleOfDot(rule);
+            ruleLambda.accept(rule);
+        });
+    }
+
+    /**
+     * Set up method-level rule of /url.character/dot.<br>
      * @param rule The rule that class default rule is already set. (NotNull)
      */
     protected void ruleOfDot(FlutyRemoteApiRule rule) {

--- a/src/main/resources/remoteapi/schema/remoteapi_schema_example_rule.js
+++ b/src/main/resources/remoteapi/schema/remoteapi_schema_example_rule.js
@@ -44,6 +44,11 @@ remoteApiRule.subPackage = function(api) {
     return baseRule.subPackage(api).replace(/\.v1/g, '');
 };
 
+// URLに記号など特殊文字がある場合に除去
+remoteApiRule.subPackage = function(api) {
+    return baseRule.subPackage(api).replace(/#/g, '');
+};
+
 // =======================================================================================
 //                                                                                Behavior
 //                                                                                ========

--- a/src/main/resources/remoteapi/schema/remoteapi_schema_tricky.json
+++ b/src/main/resources/remoteapi/schema/remoteapi_schema_tricky.json
@@ -228,6 +228,51 @@
         ]
       }
     },
+    "/urlcharacter/dot.dot.dot/": {
+      "get": {
+        "summary": "@author jflute",
+        "description": "URL contains dot",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "success"
+          }
+        },
+        "produces": [
+          "application/json"
+        ]
+      }
+    },
+    "/urlcharacter/file.pdf": {
+      "get": {
+        "summary": "@author jflute",
+        "description": "URL contains dot",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "success"
+          }
+        },
+        "produces": [
+          "application/json"
+        ]
+      }
+    },
+    "/url.character/dot": {
+      "get": {
+        "summary": "@author jflute",
+        "description": "URL contains dot",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "success"
+          }
+        },
+        "produces": [
+          "application/json"
+        ]
+      }
+    },
     "/schemaallof/simple/": {
       "post": {
         "summary": "@author jflute",

--- a/src/test/java/org/docksidestage/remote/tricky/urlcharacter/RemoteTrickyUrlcharacterBhvTest.java
+++ b/src/test/java/org/docksidestage/remote/tricky/urlcharacter/RemoteTrickyUrlcharacterBhvTest.java
@@ -14,7 +14,6 @@
  * governing permissions and limitations under the License.
  */
 package org.docksidestage.remote.tricky.urlcharacter;
-
 import javax.annotation.Resource;
 
 import org.dbflute.remoteapi.mock.MockHttpClient;
@@ -33,6 +32,21 @@ public class RemoteTrickyUrlcharacterBhvTest extends UnitRemoteapigenTestCase {
     public void test_requestHyphenhyphen() {
         // ## Act ##
         createBhv(null).requestHyphenhyphen();
+    }
+
+    public void test_requestDotdot() {
+        // ## Act ##
+        createBhv(null).requestDotdot();
+    }
+
+    public void test_requestDotdotdot() {
+        // ## Act ##
+        createBhv(null).requestDotdotdot();
+    }
+
+    public void test_requestFilepdf() {
+        // ## Act ##
+        createBhv(null).requestFilepdf();
     }
 
     public void test_requestDot() {


### PR DESCRIPTION
URLにドットをrule.jsのsubPackageで除去するようにしました。
一部記号文字はもとから除去していました。そこに足しました。
除去しつつ、除去した箇所で単語の区切りは保持するようにしておけばなというところですが、
互換性考えると厳しいのでそのままにしています。

remoteapi_schema_example_rule.jsにほかに不都合な記号がある場合の除去方法を書いておきました。